### PR TITLE
Support comment stringslint:ignore on code

### DIFF
--- a/Tests/StringsLintFrameworkTests/Parsers/ObjcParserTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/ObjcParserTests.swift
@@ -123,5 +123,25 @@ CustomLocalizedStringFromTable(@\"abc\", @\"table\", nil)
         XCTAssertEqual(results.get(0)?.locale, Locale.none)
         XCTAssertEqual(results.get(0)?.location, Location(file: file, line: 1))
     }
-    
+
+    func testIgnoreLine() throws {
+
+        let content = """
+NSLocalizedString(@\"abc\", nil)
+NSLocalizedString(@\"def\", nil) //stringslint:ignore
+"""
+
+        let file = try self.createTempFile("test1.m", with: content)
+
+        let parser = ObjcParser(implicitMacros: [], explicitMacros: [])
+        let results = try parser.parse(file: file)
+
+        XCTAssertEqual(results.count, 1)
+
+        XCTAssertEqual(results.get(0)?.key, "abc")
+        XCTAssertEqual(results.get(0)?.table, "Localizable")
+        XCTAssertEqual(results.get(0)?.locale, Locale.none)
+        XCTAssertEqual(results.get(0)?.location, Location(file: file, line: 1))
+    }
+
 }

--- a/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
@@ -179,4 +179,24 @@ Text(LocalizedStringKey("def"), tableName: "Other")
         XCTAssertEqual(results[1].locale, .none)
         XCTAssertEqual(results[1].location, Location(file: file, line: 2))
     }
+
+    func testIgnore() throws {
+
+        let content = """
+Text(LocalizedStringKey("abc"))
+Text(LocalizedStringKey("def")) //stringslint:ignore
+"""
+
+        let file = try self.createTempFile("test1.swift", with: content)
+
+        let parser = SwiftParser()
+        let results = try parser.parse(file: file)
+
+        XCTAssertEqual(results.count, 1)
+
+        XCTAssertEqual(results[0].key, "abc")
+        XCTAssertEqual(results[0].table, "Localizable")
+        XCTAssertEqual(results[0].locale, .none)
+        XCTAssertEqual(results[0].location, Location(file: file, line: 1))
+    }
 }


### PR DESCRIPTION
This allows you to have fixture or hardcoded strings in the app, and not be bothered by stringslint