### PR TITLE
support specifying a custom regex

### DIFF
--- a/Sources/StringsLintFramework/Models/RegexConfiguration.swift
+++ b/Sources/StringsLintFramework/Models/RegexConfiguration.swift
@@ -1,0 +1,35 @@
+//
+//  CustomRegex.swift
+//
+//
+//  Created by Jalal Awqati on 18/02/2024.
+//
+
+import Foundation
+
+public struct CustomRegex {
+
+    private enum Key: String {
+        case pattern
+        case matchIndex = "match_index"
+    }
+
+    let pattern: String
+    let matchIndex: Int
+
+    init(pattern: String, matchIndex: Int) {
+        self.pattern = pattern
+        self.matchIndex = matchIndex
+    }
+
+    init?(config: Any?) {
+        if let config = config,
+           let pattern = defaultDictionaryValue(config, for: Key.pattern.rawValue) as? String,
+           let matchIndex = defaultDictionaryValue(config, for: Key.matchIndex.rawValue) as? Int {
+            self.pattern = pattern
+            self.matchIndex = matchIndex
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/StringsLintFramework/Parsers/Configuration/SwiftParserConfiguration.swift
+++ b/Sources/StringsLintFramework/Parsers/Configuration/SwiftParserConfiguration.swift
@@ -11,13 +11,16 @@ public struct SwiftParserConfiguration {
     
     private enum Key: String {
         case macros = "macros"
+        case customRegex = "regex"
     }
     
     public var macros: [String] = [
         "NSLocalizedString",
         "CFLocalizedString"
         ]
-    
+
+    public var customRegex: CustomRegex?
+
     public mutating func apply(_ configuration: Any) throws {
         
         guard let configuration = configuration as? [String: Any] else {
@@ -25,6 +28,7 @@ public struct SwiftParserConfiguration {
         }
         
         self.macros += defaultStringArray(configuration[Key.macros.rawValue])
+        self.customRegex = CustomRegex(config: configuration[Key.customRegex.rawValue])
     }
     
 }

--- a/Tests/StringsLintFrameworkTests/Parsers/Configuration/SwiftParserConfigurationTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/Configuration/SwiftParserConfigurationTests.swift
@@ -15,6 +15,9 @@ class SwiftParserConfigurationTests: ConfigurationTestCase {
         let content = """
 macros:
 - ABCString
+regex:
+    pattern: ^\"([^\"]+)\".localized$
+    match_index: 2
 """
         
         let data = try self.creareConfigFileAsDictionary(with: content)
@@ -24,6 +27,8 @@ macros:
         
         XCTAssertEqual(configuration.macros.count, 3)
         XCTAssertEqual(configuration.macros, [ "NSLocalizedString", "CFLocalizedString", "ABCString" ])
+        XCTAssertEqual(configuration.customRegex?.pattern, "^\"([^\"]+)\".localized$")
+        XCTAssertEqual(configuration.customRegex?.matchIndex, 2)
     }
 
 }

--- a/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
@@ -121,7 +121,27 @@ ABCLocalizedString(\"abc\", tableName: \"Extras\", comment: \"blabla\")
         XCTAssertEqual(results[1].locale, .none)
         XCTAssertEqual(results[1].location, Location(file: file, line: 2))
     }
-    
+
+    func testParseCustomRegex() throws {
+        
+        let content = """
+\"blabla\".localized
+"""
+
+        let file = try self.createTempFile("test1.swift", with: content)
+
+        let customRegex = CustomRegex(pattern: "^\"([^\"]+)\".localized$", matchIndex: 1)
+        let parser = SwiftParser(macros: [], customRegex: customRegex)
+        let results = try parser.parse(file: file)
+        
+        XCTAssertEqual(results.count, 1)
+        
+        XCTAssertEqual(results[0].key, "blabla")
+        XCTAssertEqual(results[0].table, "Localizable")
+        XCTAssertEqual(results[0].locale, .none)
+        XCTAssertEqual(results[0].location, Location(file: file, line: 1))
+    }
+
     func testSwiftUITextWithImplicitString() throws {
 
         let content = """


### PR DESCRIPTION
I have a convenient extension around `NSLocalizedString`:

```swift
var localized: String {
   NSLocalizedString(self, comment: "")
}
```

To make `SwiftParser` recognize this pattern I need to pass it a custom regex. This branch does exactly that. The configuration yml `.stringslint.yml` could then have:

```
swift_parser:
  regex:
    pattern: "\"([^\"]+)\".localized"
    match_index: 1
```

The match index indicates which index of the regex matches represents the localization key.

Please let me know if this is something you'd like to merge, otherwise I can move this to my fork. Thanks for the nice tool!