### PR TITLE
NSLocalizedString with value

### DIFF
--- a/Sources/StringsLintFramework/Models/LocalizedString.swift
+++ b/Sources/StringsLintFramework/Models/LocalizedString.swift
@@ -8,6 +8,7 @@
 public struct LocalizedString: CustomStringConvertible, Hashable {
     let key: String
     let table: String
+    let value: String?
     let locale: Locale
     let location: Location
     var comment: String? = nil
@@ -16,6 +17,7 @@ public struct LocalizedString: CustomStringConvertible, Hashable {
         return [
             "table: \(self.table)",
             "key: \(self.key)",
+            "value: \(self.value ?? "nil")",
             "locale: \(self.locale)",
         ].joined(separator: ", ")
     }

--- a/Sources/StringsLintFramework/Parsers/ObjcParser.swift
+++ b/Sources/StringsLintFramework/Parsers/ObjcParser.swift
@@ -87,8 +87,8 @@ public struct ObjcParser: LocalizableParser {
                     table = String(text[Range(result.range(at: 3), in: text)!])
                 }
                 
-                strings.append(LocalizedString(key: key, table: table, locale: .none, location: location))
-                
+                strings.append(LocalizedString(key: key, table: table, value: nil, locale: .none, location: location))
+
             }
         } catch let error {
             print("invalid regex: \(error.localizedDescription)")
@@ -104,7 +104,7 @@ public struct ObjcParser: LocalizableParser {
                     key = String(text[Range(result.range(at: 2), in: text)!])
                 }
                 
-                strings.append(LocalizedString(key: key, table: "Localizable", locale: .none, location: location))
+                strings.append(LocalizedString(key: key, table: "Localizable", value: nil, locale: .none, location: location))
                 
             }
         } catch let error {

--- a/Sources/StringsLintFramework/Parsers/StringsParser.swift
+++ b/Sources/StringsLintFramework/Parsers/StringsParser.swift
@@ -42,7 +42,7 @@ public struct StringsParser: LocalizableParser {
                 let previousLine = (index > 0) ? file.lines[index - 1] : ""
                 let commentForLocalizedString = previousLine.extractComment()
 
-                strings.append(LocalizedString(key: key, table: tableName, locale: locale, location: Location(file: file, line: index+1), comment: commentForLocalizedString))
+                strings.append(LocalizedString(key: key, table: tableName, value: nil, locale: locale, location: Location(file: file, line: index+1), comment: commentForLocalizedString))
             }
         }
 

--- a/Sources/StringsLintFramework/Parsers/StringsdictParser.swift
+++ b/Sources/StringsLintFramework/Parsers/StringsdictParser.swift
@@ -43,7 +43,7 @@ public struct StringsdictParser: LocalizableParser {
             if let index = file.lines.firstIndex(where: { (line) -> Bool in
                 line.contains(key)
             }) {
-                strings.append(LocalizedString(key: key, table: tableName, locale: locale, location: Location(file: file, line: index+1)))
+                strings.append(LocalizedString(key: key, table: tableName, value: nil, locale: locale, location: Location(file: file, line: index+1)))
             }
         }
         

--- a/Sources/StringsLintFramework/Parsers/XibParser.swift
+++ b/Sources/StringsLintFramework/Parsers/XibParser.swift
@@ -65,7 +65,7 @@ public struct XibParser: LocalizableParser {
                     key = String(text[Range(result.range(at: 2), in: text)!])
                 }
                 
-                strings.append(LocalizedString(key: key, table: "Localizable", locale: .none, location: location))
+                strings.append(LocalizedString(key: key, table: "Localizable", value: nil, locale: .none, location: location))
                 
             }
         } catch let error {

--- a/Sources/StringsLintFramework/Rules/Lint/MissingRule.swift
+++ b/Sources/StringsLintFramework/Rules/Lint/MissingRule.swift
@@ -88,6 +88,9 @@ public class MissingRule: LintRule {
             if self.ignoredStrings.contains(string.key) {
                 return nil
             }
+            if string.value != nil {
+                return nil
+            }
             return self.buildViolation(key: string.key, location: string.location)
         })
     }

--- a/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
@@ -79,7 +79,7 @@ NSLocalizedString(\"abc\", tableName: \"ttt\", comment: \"blabla\")
     func testParseSingleStringWithTableAndValue() throws {
 
         let content = """
-NSLocalizedString(\"abc\", tableName: \"ttt\", value: \"v", comment: \"blabla\")
+NSLocalizedString(\"abc\", tableName: \"ttt\", value: \"v\", comment: \"blabla\")
 """
 
         let file = try self.createTempFile("test3.swift", with: content)

--- a/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
+++ b/Tests/StringsLintFrameworkTests/Parsers/SwiftParserTests.swift
@@ -45,11 +45,13 @@ NSLocalizedString(\"def\", tableName: \"ttt\", comment: \"blabla\")
         
         XCTAssertEqual(results[0].key, "abc")
         XCTAssertEqual(results[0].table, "Localizable")
+        XCTAssertEqual(results[0].value, nil)
         XCTAssertEqual(results[0].locale, .none)
         XCTAssertEqual(results[0].location, Location(file: file, line: 1))
         
         XCTAssertEqual(results[1].key, "def")
         XCTAssertEqual(results[1].table, "ttt")
+        XCTAssertEqual(results[0].value, nil)
         XCTAssertEqual(results[1].locale, .none)
         XCTAssertEqual(results[1].location, Location(file: file, line: 2))
     }
@@ -69,10 +71,31 @@ NSLocalizedString(\"abc\", tableName: \"ttt\", comment: \"blabla\")
         
         XCTAssertEqual(results[0].key, "abc")
         XCTAssertEqual(results[0].table, "ttt")
+        XCTAssertEqual(results[0].value, nil)
         XCTAssertEqual(results[0].locale, .none)
         XCTAssertEqual(results[0].location, Location(file: file, line: 1))
     }
     
+    func testParseSingleStringWithTableAndValue() throws {
+
+        let content = """
+NSLocalizedString(\"abc\", tableName: \"ttt\", value: \"v", comment: \"blabla\")
+"""
+
+        let file = try self.createTempFile("test3.swift", with: content)
+
+        let parser = SwiftParser()
+        let results = try parser.parse(file: file)
+
+        XCTAssertEqual(results.count, 1)
+
+        XCTAssertEqual(results[0].key, "abc")
+        XCTAssertEqual(results[0].table, "ttt")
+        XCTAssertEqual(results[0].value, "v")
+        XCTAssertEqual(results[0].locale, .none)
+        XCTAssertEqual(results[0].location, Location(file: file, line: 1))
+    }
+
     func testParseMultipleStringsOnSingleLine() throws {
         
         let content = """

--- a/Tests/StringsLintFrameworkTests/Rules/Lint/MissingRuleTests.swift
+++ b/Tests/StringsLintFrameworkTests/Rules/Lint/MissingRuleTests.swift
@@ -30,4 +30,14 @@ final class MissingRuleTests: XCTestCase {
 
         XCTAssertEqual(rule.violations.count, 0)
     }
+
+    func testStringWithValueShouldNotTrigger() {
+
+        let file = File(name: "MainView.swift", content: "NSLocalizedString(\"abc\", value: \"v\", comment: \"blabla\")")
+
+        let rule = MissingRule()
+        rule.processFile(file)
+
+        XCTAssertEqual(rule.violations.count, 0)
+    }
 }


### PR DESCRIPTION
NSLocalizedString macro support a default value in case of missing translation.

This PR add support to this usecase, ensuring the Missing rule will not trigger.